### PR TITLE
Revert "Bump pytest from 7.3.1 to 7.3.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ absl-py==1.4.0
 configobj==5.0.8
 html5lib==1.1
 pyotp==2.8.0
-pytest==7.3.2
+pytest==7.3.1
 pytruth==1.1.0
 requests==2.31.0
 ruff==0.0.272


### PR DESCRIPTION
Reverts google/github_nonpublic_api#25