### PR TITLE
Fix application install.

### DIFF
--- a/github_nonpublic_api/api.py
+++ b/github_nonpublic_api/api.py
@@ -133,8 +133,12 @@ class Api(object):
         """Installs the specified app on the given organization."""
         url = _INSTALL_APP_URL.format(app_name=app_name, org_id=org_id)
 
+        def _install_app_callback(data):
+            data['install_target'] = 'all'
+
         _get_and_submit_form(session=self._session,
                              url=url,
+                             data_callback=_install_app_callback,
                              form_matcher=lambda form: app_name in form.attrib.get('action'))
 
     def toggle_app_suspended(self, org_name: str, app_install_id: int):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,6 +105,7 @@ class TestApi(TestCase):
         AssertThat(self.session.post).WasCalled().Once().With(
             'https://github.com/apps/test-app/installations', data={
                 'authenticity_token': 'value',
+                'install_target': 'all',
             })
 
     def test_suspend_app_toggle(self):


### PR DESCRIPTION
Sometimes the default is selected repos, sometimes it is all repos.  Our default behavior will be all repos.
We should come back at some point and make this more flexible.