### PR TITLE
feat: added api to approve permission updates for a GitHub app installation

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,34 +1,33 @@
-name: Python lint and test
+name: "Python lint and test"
 
 on:
   pull_request:
   push:
-  workflow_dispatch:    
+  workflow_dispatch:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # ratchet:actions/checkout@v3
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: "actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236" # ratchet:actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+          python-version: "${{ matrix.python-version }}"
+      - name: "Install dependencies"
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with ruff
+      - name: "Lint with ruff"
         run: |
           # stop the build if there are Python syntax errors or undefined names
           ruff --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
           # default set of ruff rules with GitHub Annotations
           ruff --output-format=github --target-version=py37 .
-      - name: Test with pytest
+      - name: "Test with pytest"
         run: |
           pytest

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,9 @@
+# This is the list of significant contributors
+#
+# This does not necessarily list everyone who has contributed code
+# especially since many employees of one corporation may be contributing
+# To see the full list of contributors, see the revision history in
+# source control
+
+Alphabet
+Google LLC

--- a/README.md
+++ b/README.md
@@ -24,3 +24,35 @@ Apache header:
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+## For Developers
+
+Create a new virtual environment and install the required tools.
+
+```bash
+python -m venv ~/{some envpath}/github_nonpublic
+
+pip install --upgrade setuptools,build,pip
+
+pip install -r requirements.txt
+```
+
+Testing:
+
+```bash
+python -m pytest
+```
+
+Linting:
+
+```bash
+ruff --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .
+
+ruff --output-format=github --target-version=py37 .
+```
+
+Adding license headers:
+
+```bash
+go run github.com/google/addlicense@v1.1.1 -c "The Authors (see AUTHORS file)" -l apache -v ./**/*.py
+```

--- a/github_nonpublic_api/__init__.py
+++ b/github_nonpublic_api/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tests/update_app_permissions.html
+++ b/tests/update_app_permissions.html
@@ -1,0 +1,48 @@
+<html>
+  <body>
+    <form
+      class="js-integrations-install-form"
+      data-turbo="false"
+      action="/organizations/test-org/settings/installations/42/permissions/update"
+      accept-charset="UTF-8"
+      method="post"
+    >
+      <input
+        type="hidden"
+        name="_method"
+        value="put"
+        autocomplete="off"
+      /><input type="hidden" name="authenticity_token" value="value" />
+      <input
+        type="hidden"
+        name="version_id"
+        id="version_id"
+        value="112233"
+        autocomplete="off"
+        class="form-control"
+      />
+      <input
+        type="hidden"
+        name="integration_fingerprint"
+        id="integration_fingerprint"
+        value="value"
+        autocomplete="off"
+        class="form-control"
+      />
+
+      <div class="text-center">
+        <button
+          type="submit"
+          class="btn btn-primary btn-block js-integrations-install-form-submit"
+        >
+          Accept new permissions
+        </button>
+      </div>
+
+      <p class="note">
+        The TestApp app will retain its current permissions if you choose not to
+        accept the new permissions.
+      </p>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
* Add a form submission api to accept the updated permissions for a GitHub App installation
* Updated `README.md` with some basic instructions for developers
* The readme called for license headers that didn't exist so I added those too

## GitHub Action Workflow Updates
* Added proper quotes to the GitHub action workflow. [Unquoted YAML can cause absolute chaos](https://ruudvanasseldonk.com/2023/01/11/the-yaml-document-from-hell). 
* Pinned the action versions to avoid unintended changes.
* I know that's out of scope of the change but I couldn't leave it like that