### PR TITLE
Change supported python version to 3.12.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: "actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744" # ratchet:actions/checkout@v3


### PR DESCRIPTION
This matches what we use internally.  AFAIK we have no external users, but when we do we should be more vocal about what version we do and don't support.  But for now just align with internal.